### PR TITLE
canvas mouse leave behaviour

### DIFF
--- a/js/pwCanvas.js
+++ b/js/pwCanvas.js
@@ -218,6 +218,11 @@ angular.module('pw.canvas-painter')
 						paint();
 					}, false);
 					canvasTmp.addEventListener(PAINT_END, copyTmpImage, false);
+					canvasTmp.addEventListener('mouseleave', function(e){
+						if(e.which === 1){
+							copyTmpImage(e);
+						}
+					}, false);
 				};
 				initListeners();
 

--- a/js/pwCanvas.js
+++ b/js/pwCanvas.js
@@ -206,19 +206,28 @@ angular.module('pw.canvas-painter')
 					ppts = [];
 				};
 
+				var startTmpImage = function(e){
+					e.preventDefault();
+					canvasTmp.addEventListener(PAINT_MOVE, paint, false);
+
+					setPointFromEvent(point, e);
+					ppts.push({x: point.x, y: point.y});
+					ppts.push({x: point.x, y: point.y});
+
+					paint();
+				};
+
 				var initListeners = function(){
-					canvasTmp.addEventListener(PAINT_START, function(e) {
-						e.preventDefault();
-						canvasTmp.addEventListener(PAINT_MOVE, paint, false);
-
-						setPointFromEvent(point, e);
-						ppts.push({x: point.x, y: point.y});
-						ppts.push({x: point.x, y: point.y});
-
-						paint();
+					canvasTmp.addEventListener(PAINT_START, startTmpImage, false);
+					canvasTmp.addEventListener('mouseenter', function(e){
+						// If the mouse is down when it enters the canvas, start a path
+						if(e.which === 1){
+							startTmpImage(e);
+						}
 					}, false);
 					canvasTmp.addEventListener(PAINT_END, copyTmpImage, false);
 					canvasTmp.addEventListener('mouseleave', function(e){
+						// If the mouse is down when it leaves the canvas, end the path
 						if(e.which === 1){
 							copyTmpImage(e);
 						}


### PR DESCRIPTION
In the current implementation of the directive, if you move the cursor out of canvas with mouse down it does not register any mouseup event that follows.

This causes the mouse to keep drawing on the canvas with the mouse up.

These commits add events to watch for entering and leaving the canvas, check if the mouse button is down and call the appropriate function if applicable. The anonymous function on PAINT_START has been refactored to a named function to make this work.
