### PR TITLE
Fixing background image size

### DIFF
--- a/js/pwCanvas.js
+++ b/js/pwCanvas.js
@@ -35,7 +35,7 @@ angular.module('pw.canvas-painter')
         if (options.imageSrc) {
           var image = new Image();
           image.onload = function() {
-            ctx.drawImage(this, 0, 0);
+            ctx.drawImage(this, 0, 0, options.width, options.height);
           };
           image.src = options.imageSrc;
         }


### PR DESCRIPTION
This will set the background image height and width to the size of canvas so that it will not show only a part a of the image if the image is bigger in size than canvas.
